### PR TITLE
Prevent registering multiple handlers when reloading plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-confirm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Show a confirmation dialog before quitting Hyper",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
When reloading plugins (by changing .hyper.js for instance) hyper-confirm will register multiple handlers and show multiple dialogs. This should fix it