### PR TITLE
Feature/windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,3 +37,24 @@ exports.onApp = (app) => {
   beforeQuitHandler = createBeforeQuitHandler(app);
   app.on('before-quit', beforeQuitHandler);
 }
+
+
+exports.middleware = (store) => (next) => (action) => {
+  switch ( action.type ) {
+    case 'CLOSE_TAB':
+      console.log("YOU SHALL NOT CLOSE!");
+      break;
+    case 'UI_COMMAND_EXEC':
+      if ( 'pane.close' == action.command ) {
+        console.log("YOU SHALL NOT CLOSE!");
+      }
+
+      next(action);
+      break;
+    default:
+      console.log("AHHHHH!");
+      console.log(action);
+      next(action);
+      break;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-confirm",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Show a confirmation dialog before quitting Hyper",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Adds a confirmation modal Hyper on Windows systems. Contrary to the macOS version, which only pops a confirmation when actually _quitting_ Hyper, the Windows implementation will pop a confirmation dialog when _closing_ a Hyper window, which is in line with standard Windows UX.