### PR TITLE
fix to make this work on newer hyper versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {dialog} = require('electron');
+const dialog = require('electron').remote.dialog;
 
 let confirmQuit = true;
 let beforeQuitHandler;


### PR DESCRIPTION
On newer hyper versions (I'm running 3.1.2) the terminal will not show up without this fix. This is because of the following error: `Uncaught TypeError: Cannot destructure property 'dialog' of 'require(...).remote' as it is undefined.`.